### PR TITLE
Add BerryPath Product Feed to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ The storefront of Magento 2 can be styled in numerous ways:
 - [magento2-withdrawl](https://github.com/Zwernemann/magento2-withdrawl) 🫡 - Magento 2 module providing a compliant EU withdrawal button required from June 19, 2026 (§356a BGB / Directive (EU) 2023/2673). Enables customers and guests to revoke orders via a simple form (name, order number, email), sends automatic confirmation emails, and allows admin management in the backend.
 - [module-blog](https://github.com/mage-os-lab/module-blog) 🫡 - Blog module for Mage-OS / Magento 2 with posts, categories, tags, authors, scheduled publishing, SEO, RSS, sitemap, 6 widgets, and a full GraphQL API. Luma + Hyvä.
 - [BerryPath Guided Selling](https://github.com/BerryPath/magento2-berrypath-flow) - Open source integration for BerryPath. Add interactive product finders and buying guides to Magento 2 storefronts with product synchronization, assisted conversion tracking + Hyvä compatibility.
+- [BerryPath Product Feed](https://github.com/BerryPath/magento2-berrypath-product-feed) - Open source Magento 2 product feed generator. Create XML product feeds with configurable attributes and multi store support for Google Shopping, Meta, Pinterest, TikTok, Microsoft Shopping, AI search engines and custom integrations.
 
 <details>
 <summary>🪦 Graveyard — projects no longer recommended</summary>


### PR DESCRIPTION
## What changed

Added **BerryPath Product Feed** to the **Marketing** section under **Open Source Extensions**.

## Why

BerryPath Product Feed is an actively maintained open source Magento 2 extension for generating product feeds for marketing channels and third party integrations.

The module supports configurable XML feeds, multi store environments, custom product attributes, and extensible feed generation for platforms such as Google Shopping, Meta, Pinterest, TikTok, Microsoft Shopping, AI search engines, and other custom integrations.

It is well documented, has stable releases, and provides a useful addition to the Marketing section for merchants looking for a flexible and developer friendly product feed solution.