### PR TITLE
Add magento.watch to Tools

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -128,3 +128,8 @@
   description: VS Code extension to view, watch and manage Magento log files and reports directly in your workspace.
   type: vendor_site
   added: "2024-01-01"
+- name: magento.watch
+  url: https://magento.watch
+  description: Release dates, end-of-life dates and system requirements for every Magento, Adobe Commerce and Mage-OS version, with a free JSON API.
+  type: vendor_site
+  added: "2026-08-20"


### PR DESCRIPTION
Adds **magento.watch** as a single entry in `data/tools.yml` (README is generated, so it is untouched).

```yaml
- name: magento.watch
  url: https://magento.watch
  description: Release dates, end-of-life dates and system requirements for every Magento, Adobe Commerce and Mage-OS version, with a free JSON API.
  type: vendor_site
  added: "2026-08-20"
```

## What it is

A version lifecycle reference for the Magento ecosystem. For every Magento Open Source, Adobe Commerce and Mage-OS version it records the release date, the end-of-life date, and the full supported range for PHP, Composer, MySQL, MariaDB, OpenSearch, Elasticsearch, Redis/Valkey, RabbitMQ, Varnish, nginx and the matching AWS managed services. Useful when scoping an upgrade or checking whether a client is still on a supported patch level.

Alongside the website there is a free, no-auth JSON API (`https://magento.watch/api`) and an MCP endpoint for coding agents.

## Notes on the entry

- `type: vendor_site` — it is a hosted service, not a repository or Composer package, so there is no star badge to render. Same treatment as the existing Mage2Gen and Tablerates Generator entries.
- Liveness: `curl -sIL -o /dev/null -w '%{http_code}' https://magento.watch` returns `200`.
- Schema-checked against `schemas/entry.schema.json` — required `name`/`type`/`added` present, `type` is in the enum, `added` matches the date pattern, no additional properties. I could not run `composer validate-data` locally (no PHP toolchain on this machine), so please let CI confirm.